### PR TITLE
Refactor actions into individual commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ and print the test file to the standard output.
 Same as "ghostwrite explicit", but saves the generated test file to a file on
 disk. 
 
+## Commands
+
+The extension defines the following commands:
+
+* `icontract-hypothesis-vscode.pick` (Show the quickpick),
+* `icontract-hypothesis-vscode.test` (Infer the Hypothesis strategies for the current file and execute them),
+* `icontract-hypothesis-vscode.test-at` (Infer the Hypothesis strategy for the function under the caret and execute it),
+* `icontract-hypothesis-vscode.inspect` (Infer the Hypothesis strategies for the current file and inspect them),
+* `icontract-hypothesis-vscode.inspect-at` (Infer the Hypothesis strategy for the function under the caret and inspect it),
+* `icontract-hypothesis-vscode.ghostwrite-explicit` (Ghostwrite and print an explicit test file for the current file), and
+* `icontract-hypothesis-vscode.ghostwrite-explicit-to` (Ghostwrite and save an explicit test file for the current file)
+
+Please see [Section "Usage"](#Usage) for more details.
+
 ## Known Issues
 
 It is hard to control terminals in VS Code (see 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,30 @@
 			{
 				"command": "icontract-hypothesis-vscode.pick",
 				"title": "icontract-hypothesis"
+			},
+			{
+				"command": "icontract-hypothesis-vscode.test",
+				"title": "Infer the Hypothesis strategies for the current file and execute them"
+			},
+			{
+				"command": "icontract-hypothesis-vscode.test-at",
+				"title": "Infer the Hypothesis strategy for the function under the caret and execute it"
+			},
+			{
+				"command": "icontract-hypothesis-vscode.inspect",
+				"title": "Infer the Hypothesis strategies for the current file and inspect them"
+			},
+			{
+				"command": "icontract-hypothesis-vscode.inspect-at",
+				"title": "Infer the Hypothesis strategy for the function under the caret and inspect it"
+			},
+			{
+				"command": "icontract-hypothesis-vscode.ghostwrite-explicit",
+				"title": "Ghostwrite and print an explicit test file for the current file"
+			},
+			{
+				"command": "icontract-hypothesis-vscode.ghostwrite-explicit-to",
+				"title": "Ghostwrite and save an explicit test file for the current file"
 			}
 		],
 		"menus": {

--- a/tips-and-tricks-for-creating-vs-code-plugin.md
+++ b/tips-and-tricks-for-creating-vs-code-plugin.md
@@ -20,7 +20,7 @@ Use output channel for process output: https://github.com/emeraldwalk/vscode-run
 
 ## Lint
 
-Fix and lint: `npx eslint src --fix`
+Fix and lint: `npx eslint src --ext ts --fix`
 
 ## Publish
 


### PR DESCRIPTION
This patch refactors all the actions (test, test-at *etc.*) into
individual VS Code commands so that they can be used in VS Code at
different places or from other extensions.

For example, the user can now direclty assign the keyboard shortcut for
`icontract-hypothesis.test` command.